### PR TITLE
Add confirmation before auto word selection

### DIFF
--- a/app/src/main/java/org/kaqui/settings/ClassSelectionActivity.kt
+++ b/app/src/main/java/org/kaqui/settings/ClassSelectionActivity.kt
@@ -138,19 +138,26 @@ class ClassSelectionActivity : BaseActivity(), CoroutineScope {
                 true
             }
             R.id.autoselect -> {
-                launch {
-                    val progressDialog = ProgressDialog(this@ClassSelectionActivity)
-                    progressDialog.setMessage(getString(R.string.autoselecting_words))
-                    progressDialog.setCancelable(false)
-                    progressDialog.show()
+                alert {
+                    title = getString(R.string.override_selection_title)
+                    message = getString(R.string.override_selection_msg)
+                    positiveButton(android.R.string.ok) {
+                        launch {
+                            val progressDialog = ProgressDialog(this@ClassSelectionActivity)
+                            progressDialog.setMessage(getString(R.string.autoselecting_words))
+                            progressDialog.setCancelable(false)
+                            progressDialog.show()
 
-                    withContext(Dispatchers.Default) { Database.getInstance(this@ClassSelectionActivity).autoSelectWords() }
+                            withContext(Dispatchers.Default) { Database.getInstance(this@ClassSelectionActivity).autoSelectWords() }
 
-                    adapter.notifyDataSetChanged()
-                    statsFragment.updateStats(dbView)
+                            adapter.notifyDataSetChanged()
+                            statsFragment.updateStats(dbView)
 
-                    progressDialog.dismiss()
-                }
+                            progressDialog.dismiss()
+                        }
+                    }
+                    negativeButton(android.R.string.cancel) {}
+                }.show()
                 return true
             }
             else ->

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -83,6 +83,8 @@
     <string name="saved_selection">Sélection courrante sauvegardée en \"%1$s\"</string>
     <string name="answerDone">Fini</string>
     <string name="enter_name_of_selection">Entrez le nom de cette sélection</string>
+    <string name="override_selection_title">Automatically populate vocabulary</string>
+    <string name="override_selection_msg">Do you want to select words based on your chosen kanji?\nThis will override your current selection.</string>
     <string name="could_not_import_file">Impossible d\'importer le fichier: %1$s</string>
     <string name="import_kanji_help">Cette fonctionalité permet d\'importer une sélection de kanji à partir d\'un fichier. Le fichier doit contenir tous les kanji à importer, sur une seule ligne, sans espace ou quelconque séparateur.</string>
     <string name="additional_kanji">Kanji additionnels</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -89,6 +89,8 @@
     <string name="saved_selection">Current selection saved as \"%1$s\"</string>
     <string name="answerDone">Done</string>
     <string name="enter_name_of_selection">Enter the name of this selection</string>
+    <string name="override_selection_title">Automatically populate vocabulary</string>
+    <string name="override_selection_msg">Do you want to select words based on your chosen kanji?\nThis will override your current selection.</string>
     <string name="could_not_import_file">Could not import file: %1$s</string>
     <string name="import_kanji_help">This feature allows importing a kanji selection from a file. The file must contain all the kanji to be imported, on a single line, without space or any separator.</string>
     <string name="additional_kanji">Additional kanji</string>


### PR DESCRIPTION
Add a confirmation dialog to prevent accidentally overriding current
vocabulary selection with word autoselection based on current kanji.

NOTE: I have temporarily added English strings to values-fr/strings.xml
as I do not speak French; these need to be translated.