### PR TITLE
Save vocab selection

### DIFF
--- a/app/src/main/java/org/kaqui/model/DatabaseUpdater.kt
+++ b/app/src/main/java/org/kaqui/model/DatabaseUpdater.kt
@@ -59,6 +59,17 @@ class DatabaseUpdater(private val database: SQLiteDatabase, private val dictDb: 
                         + "name TEXT NOT NULL"
                         + ")")
         database.execSQL(
+                "CREATE TABLE IF NOT EXISTS ${Database.WORDS_ITEM_SELECTION_TABLE_NAME} ("
+                        + "id_selection INTEGER NOT NULL,"
+                        + "id_word INTEGER NOT NULL REFERENCES words(id),"
+                        + "PRIMARY KEY(id_selection, id_word)"
+                        + ")")
+        database.execSQL(
+                "CREATE TABLE IF NOT EXISTS ${Database.WORDS_SELECTION_TABLE_NAME} ("
+                        + "id_selection INTEGER PRIMARY KEY,"
+                        + "name TEXT NOT NULL"
+                        + ")")
+        database.execSQL(
                 "CREATE TABLE IF NOT EXISTS ${Database.WORDS_TABLE_NAME} ("
                         + "id INTEGER PRIMARY KEY,"
                         + "item TEXT NOT NULL,"
@@ -115,6 +126,8 @@ class DatabaseUpdater(private val database: SQLiteDatabase, private val dictDb: 
             database.execSQL("DROP TABLE IF EXISTS main.${Database.ITEM_STROKES_TABLE_NAME}")
             database.execSQL("DROP TABLE IF EXISTS main.${Database.KANJIS_ITEM_SELECTION_TABLE_NAME}")
             database.execSQL("DROP TABLE IF EXISTS main.${Database.KANJIS_SELECTION_TABLE_NAME}")
+            database.execSQL("DROP TABLE IF EXISTS main.${Database.WORDS_ITEM_SELECTION_TABLE_NAME}")
+            database.execSQL("DROP TABLE IF EXISTS main.${Database.WORDS_SELECTION_TABLE_NAME}")
             database.execSQL("DROP TABLE IF EXISTS main.${Database.KANJIS_COMPOSITION_TABLE_NAME}")
             database.execSQL("DROP TABLE IF EXISTS main.${Database.KANJIS_TABLE_NAME}")
             database.execSQL("DROP TABLE IF EXISTS main.${Database.KANAS_TABLE_NAME}")

--- a/app/src/main/java/org/kaqui/settings/ClassSelectionActivity.kt
+++ b/app/src/main/java/org/kaqui/settings/ClassSelectionActivity.kt
@@ -130,7 +130,9 @@ class ClassSelectionActivity : BaseActivity(), CoroutineScope {
                 true
             }
             R.id.load_selection -> {
-                startActivity(Intent(this, SavedSelectionsActivity::class.java))
+                val intent = Intent(this, SavedSelectionsActivity::class.java)
+                intent.putExtra("org.kaqui.MODE", mode.name)
+                startActivity(intent)
                 true
             }
             R.id.import_kanji_selection -> {
@@ -171,7 +173,10 @@ class ClassSelectionActivity : BaseActivity(), CoroutineScope {
     }
 
     private fun saveSelection(name: String) {
-        Database.getInstance(this).saveKanjiSelectionTo(name)
+        when (mode) {
+            Mode.KANJI -> Database.getInstance(this).saveKanjiSelectionTo(name)
+            Mode.WORD -> Database.getInstance(this).saveWordSelectionTo(name)
+        }
         toast(getString(R.string.saved_selection, name))
     }
 

--- a/app/src/main/java/org/kaqui/settings/SavedSelectionsAdapter.kt
+++ b/app/src/main/java/org/kaqui/settings/SavedSelectionsAdapter.kt
@@ -9,7 +9,7 @@ import org.jetbrains.anko.*
 import org.kaqui.R
 import org.kaqui.model.Database
 
-class SavedSelectionsAdapter(context: Context, var savedSelections: List<Database.KanjiSelection>) : BaseAdapter() {
+class SavedSelectionsAdapter(context: Context, var savedSelections: List<Database.SavedSelection>) : BaseAdapter() {
     private val ankoContext = AnkoContext.createReusable(context, this)
 
     private fun createView() = ankoContext.apply {
@@ -25,7 +25,7 @@ class SavedSelectionsAdapter(context: Context, var savedSelections: List<Databas
         return view
     }
 
-    override fun getItem(position: Int): Database.KanjiSelection {
+    override fun getItem(position: Int): Database.SavedSelection {
         return savedSelections[position]
     }
 

--- a/app/src/main/res/menu/word_jlpt_selection_menu.xml
+++ b/app/src/main/res/menu/word_jlpt_selection_menu.xml
@@ -12,4 +12,10 @@
         app:showAsAction="always"
         android:title="@string/autoselect_from_kanji"
         android:titleCondensed="@string/autoselect_from_kanji_short"/>
+    <item
+        android:id="@+id/save_selection"
+        android:title="@string/save_current_selection" />
+    <item
+        android:id="@+id/load_selection"
+        android:title="@string/load_selection" />
 </menu>


### PR DESCRIPTION
This pull request implements saving vocabulary selections and restoring them, akin to the save feature for kanji. In this implementation, the save functions use separate database tables and functions but the same interface and activities; therefore, SavedSelectionsActivity needs to be parameterized with the current mode (KANJI or WORD).

Note: This feature requires a new database version and database upgrade which I have not implemented. As such, it will currently not work and/or crash with an already existing database.